### PR TITLE
Fix: including millisecond trailing zeros

### DIFF
--- a/psiphon/common/utils.go
+++ b/psiphon/common/utils.go
@@ -35,7 +35,7 @@ import (
 	"time"
 )
 
-const RFC3339Milli = "2006-01-02T15:04:05.999Z07:00"
+const RFC3339Milli = "2006-01-02T15:04:05.000Z07:00"
 
 // Contains is a helper function that returns true
 // if the target string is in the list.


### PR DESCRIPTION
https://golang.org/src/time/format.go#L119